### PR TITLE
New command for Complex Forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ All boxes are environments that are used with `\begin{name}` and `\end{name}`.
 
 - `columnbox`: creates a red box in one column. The Layout changes depending on which column it's in and should dynamically do the right thing; should a box refuse to play nice, you can force it into a configuration using `\begin{columnbox}[l]` or `\begin{columnbox}[r]`.
 - `twocolbox`: like `columnbox`, only the box spreads over both columns. Optional arguments apply as well.
-- `blackbox`: creates a dark-themed box. With white text. Takes a title as argument.
+- `blackbox`: creates a single column dark-themed box. With white text. Takes a title as argument.
+- `twocolblackbox`: like `blackbox`, but two columns.
 - `examplebox`: Creates a white box used for example texts.
 - `twocolexamplebox`: Like `examplebox`, but two columns.
   
@@ -87,7 +88,7 @@ All boxes are environments that are used with `\begin{name}` and `\end{name}`.
 
 ### Tables
 
-The environment `\begin{srtable}{layout}{Header}` & `\end{srtable}` creates a table to be used within a `twocolumnblackbox`. Layout describes [tabularx column-Layout](https://en.wikibooks.org/wiki/LaTeX/Tables#The_tabularx_package). The body contains all lines of the table except for the header line, which is provided through the second argument.
+The environment `\begin{srtable}{layout}{Header}` & `\end{srtable}` creates a table to be used within a `blackbox` or `twocolumnblackbox`. Layout describes [tabularx column-Layout](https://en.wikibooks.org/wiki/LaTeX/Tables#The_tabularx_package). The body contains all lines of the table except for the header line, which is provided through the second argument.
 
 ### Small Sections
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ These sections are environments as well.
 ### Other commands
 
 - `spellblock`: This command takes 4 arguments and a 5th optional one. `\spellblock[Damage]{Type}{Range}{Duration}{Drain}`. This can be used in the `spell` environment to add the core spell features.
+- `cformblock`: This command takes 3 arguments. `\cformblock[Target]{Duration}{Fading}`. Just like `spellblock` this can be used in the `spell` environment to add complex forms.
 
 ### Indexing
 To create an index entry for a term, write `\index{Term}` in the text where you want the entry to link to.

--- a/ShadowTeXSR5.cls
+++ b/ShadowTeXSR5.cls
@@ -163,6 +163,9 @@
 \def\srbb@spelltype{}
 \def\srbb@spelldur{}
 \def\srbb@spelldmg{}
+\def\srbb@cformtarg{}
+\def\srbb@cformdur{}
+\def\srbb@cformfade{}
 \def\srbb@example{}
 
 %%%%%%%%%%%%%%%%%%%%
@@ -984,6 +987,12 @@ boxed title style={arc=0mm, top=2mm, bottom=1mm, colframe=storyblack, colback=st
 \par
 }
 
+\newcommand{\cformblock}[3][]{
+\begin{tabular}{lll}
+\textbf{\srbb@cformtarg:} #1 & \textbf{\srbb@cformdur:} #2 & \textbf{\srbb@cformfade:} #3 \\
+\end{tabular}
+}
+
 \newcommand{\srmaketitle}[1][black]{
   \def\coverframe{cover-}
   \g@addto@macro\coverframe{#1}
@@ -1102,6 +1111,9 @@ boxed title style={arc=0mm, top=2mm, bottom=1mm, colframe=storyblack, colback=st
   \renewcommand{\srbb@spelldur}{Duration}
   \renewcommand{\srbb@spelldrain}{Drain}
   \renewcommand{\srbb@spelldmg}{Damage}
+  \renewcommand{\srbb@cformtarg}{Target}
+  \renewcommand{\srbb@cformdur}{Duration}
+  \renewcommand{\srbb@cformfade}{Fading}
   \renewcommand{\srbb@example}{Example}
 }
 
@@ -1116,6 +1128,9 @@ boxed title style={arc=0mm, top=2mm, bottom=1mm, colframe=storyblack, colback=st
   \renewcommand{\srbb@spelldur}{Dauer}
   \renewcommand{\srbb@spelldrain}{Entzug}
   \renewcommand{\srbb@spelldmg}{Schaden}
+  \renewcommand{\srbb@cformtarg}{Ziel}
+  \renewcommand{\srbb@cformdur}{Dauer}
+  \renewcommand{\srbb@cformfade}{Schwund}
   \renewcommand{\srbb@example}{Beispiel}
 }
 

--- a/ShadowTeXSR5.cls
+++ b/ShadowTeXSR5.cls
@@ -11,7 +11,6 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesClass{ShadowTeXSR5}[2020/01/11 - Shadowrun Rulebook Template]
 
@@ -141,7 +140,6 @@
     \end{multicols*}%
   }{}%
 }
-
 
 %%%%%%%%%%%%%%%%%%%%
 %%
@@ -389,6 +387,7 @@
 %% PAGESTYLES/HEADER AND FOOTER
 %%
 %%%%%%%%%%%%%%%%%%%%
+
 \graphicspath{{./images/}}
 \RequirePackage{fancyhdr}
 
@@ -538,8 +537,6 @@
 \titleformat{\subsubsection}
   {\headerfont\large\raggedright\nohyphens}{}{0cm}{\MakeUppercase}[{\color{black}\nobreak\titlerule}]
 
-
-
 %%%%%%%%%%%%%%%
 %% NEW CHAPTER DEFS
 %%%
@@ -629,6 +626,7 @@
 %%%%%%%%%%%%%%%%%%%
 %% IMAGES
 %%%
+
 \newcommand{\twocolimage}[1]{
 \begin{tcolorbox}[
     enhanced,
@@ -968,7 +966,6 @@ boxed title style={arc=0mm, top=2mm, bottom=1mm, colframe=storyblack, colback=st
 \BODY
 }
 
-
 %%%%%%%%%%%%%%%%%%%%
 %%
 %% NEW COMMANDS II
@@ -1087,13 +1084,11 @@ boxed title style={arc=0mm, top=2mm, bottom=1mm, colframe=storyblack, colback=st
 
 \RequirePackage[hidelinks]{hyperref}
 
-
 %%%%%%%%%%%%%%%%%%%%
 %%
 %% TERMINOLOGY
 %%
 %%%%%%%%%%%%%%%%%%%%
-
 
 \PassOptionsToPackage{ngerman}{babel}
 \PassOptionsToPackage{english}{babel}
@@ -1134,13 +1129,9 @@ boxed title style={arc=0mm, top=2mm, bottom=1mm, colframe=storyblack, colback=st
   \renewcommand{\srbb@example}{Beispiel}
 }
 
-
-
 \graphicspath{{./images/}}
 
 \indexsetup{level=\section*,toclevel=chapter}
 \makeindex[options= -s ./index_style.ist, intoc]
 \AtEndDocument{\cleardoublepage\restorepagecolor\globalcolor{black}\pagestyle{plain}\printindex}
 \frontmatter
-
-

--- a/ShadowTeXSR5.cls
+++ b/ShadowTeXSR5.cls
@@ -683,6 +683,28 @@
 \begin{tcolorbox}[
 enhanced, 
 fonttitle=\boxfont, 
+float=tb, 
+colback=storyblack, 
+left=2mm, 
+right=2mm, 
+bottom=6mm, top=3mm, 
+title={\color{yellowtext}\Large\MakeUppercase{#1}}, 
+width = \columnwidth, 
+arc=0mm, 
+outer arc=0mm, 
+colframe=storyblack, 
+attach boxed title to top left={yshift=-1mm}, 
+boxed title style={arc=0mm, top=2mm, bottom=1mm, colframe=storyblack, colback=storyblack, outer arc=0mm}, underlay boxed title={\fill[storyblack] ($(title.north east)+(-2mm, 0mm)$) -- ($(title.south east)+(-2mm, 0mm)$) -- ($(title.south east)+(2mm, 0mm)$) -- ++(2cm, 0mm) -- ($(title.north east)+(2mm, 0mm)$) -- cycle;}
+]
+\centering
+#2
+\end{tcolorbox}
+}
+
+\newcommand{\sr@dblblckbox}[2]{
+\begin{tcolorbox}[
+enhanced, 
+fonttitle=\boxfont, 
 float*=tb, 
 colback=storyblack, 
 left=2mm, 
@@ -878,6 +900,10 @@ boxed title style={arc=0mm, top=2mm, bottom=1mm, colframe=storyblack, colback=st
 
 \NewEnviron{blackbox}[1]{
 \sr@blckbox{#1}{\BODY}
+}
+
+\NewEnviron{twocolblackbox}[1]{
+\sr@dblblckbox{#1}{\BODY}
 }
 
 \NewEnviron{columnbox}[1][]{


### PR DESCRIPTION
Adds the command `\cformblock[target]{duration}{fading}` for complex forms (just like there is a command for spells) to be used within the `spell` environment.